### PR TITLE
#9 Time until departure as hours and minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This card generates a simple departure card for the RMV public transport service
 | hide_title        | boolean | **Optional** | Hide card title                             | `false`                    |
 | hide_minutes      | boolean | **Optional** | Hide minutes until departure                | `false`                    |
 | show_time         | boolean | **Optional** | Show absolute departure time                | `false`                    |
-
+| convert_minutes   | boolean | **Optional** | Show minutes until departure as hh:mm       | `false`                    |
 
 ## Installation
 

--- a/info.md
+++ b/info.md
@@ -12,3 +12,4 @@ This card generates a simple departure card for the RMV public transport service
 | hide_title        | boolean | **Optional** | Hide card title                             | `false`                    |
 | hide_minutes      | boolean | **Optional** | Hide minutes until departure                | `false`                    |
 | show_time         | boolean | **Optional** | Show absolute departure time                | `false`                    |
+| convert_minutes   | boolean | **Optional** | Show minutes until departure as hh:mm       | `false`                    |

--- a/rmv-card.js
+++ b/rmv-card.js
@@ -1,4 +1,13 @@
 class RmvCard extends HTMLElement {
+  sec2time(timeInSeconds) {
+    var pad = function(num, size) { return ('000' + num).slice(size * -1); },
+        time = parseFloat(timeInSeconds).toFixed(3),
+        hours = Math.floor(time / 60 / 60),
+        minutes = Math.floor(time / 60) % 60;
+
+    return pad(hours, 2) + ':' + pad(minutes, 2);
+  }
+
   set hass(hass) {
     const entityId = this.config.entity
     const state = hass.states[entityId]
@@ -76,7 +85,7 @@ class RmvCard extends HTMLElement {
 
       const jtime = new Date(journey['departure_time'] + 'Z')
       const time = jtime.toISOString().substr(11, 5)
-      const minutes = parseInt(journey['minutes'])
+      const departureIn = this.config.convert_minutes ? this.sec2time(parseInt(journey['minutes'])*60) : parseInt(journey['minutes'])
 
       tablehtml += `
         <tr>
@@ -84,7 +93,7 @@ class RmvCard extends HTMLElement {
           <td class="expand">${destination}</td>
       `
       tablehtml += `          <td class="shrink" style="text-align:right;">`
-      if (!this.config.hide_minutes) { tablehtml += `${minutes}` }
+      if (!this.config.hide_minutes) { tablehtml += `${departureIn}` }
       if (this.config.show_time) { tablehtml += ` <small>(${time})</small>` }
       tablehtml += `</td>`
 


### PR DESCRIPTION
I've added the feature as described in #9 
if the option convert_minutes is activated, the time until departure will be shown as hh:mm